### PR TITLE
redux: excluded extra containers

### DIFF
--- a/React/redux/src/Components/addItem.js
+++ b/React/redux/src/Components/addItem.js
@@ -1,27 +1,15 @@
-import React, { Component } from "react";
 import { AddPackingItem } from "packlist-components";
 import { ItemActionCreators } from "../Redux/Actions/items";
 import { connect } from "react-redux";
 
-class AddItems extends Component {
-  render() {
-    return (
-      <AddPackingItem
-        addItem={() => this.props.dispatch(ItemActionCreators.addItem())}
-        setNewItemText={e =>
-          this.props.dispatch(ItemActionCreators.setNewItemName(e.target.value))
-        }
-        value={this.props.newItemName}
-        clear={() => this.props.dispatch(ItemActionCreators.clear())}
-      />
-    );
-  }
-}
+const mapStateToProps = state => ({ newItemName: state.items.newItemName });
 
-const mapStateToProps = state => {
-  return {
-    newItemName: state.items.newItemName
-  };
+const { setNewItemName, addItem, clear } = ItemActionCreators;
+
+const mapDispathToProps = {
+  setNewItemText: e => setNewItemName(e.target.value),
+  addItem,
+  clear
 };
 
-export default connect(mapStateToProps)(AddItems);
+export default connect(mapStateToProps, mapDispathToProps)(AddPackingItem);

--- a/React/redux/src/Components/listItems.js
+++ b/React/redux/src/Components/listItems.js
@@ -1,17 +1,6 @@
-import React, { Component } from "react";
 import { SimpleList } from "packlist-components";
 import { connect } from "react-redux";
 
-class ListItems extends Component {
-  render() {
-    return <SimpleList value={this.props.allItems} />;
-  }
-}
+const mapStateToProps = state => ({ value: state.items.myItems });
 
-const mapStateToProps = state => {
-  return {
-    allItems: state.items.myItems
-  };
-};
-
-export default connect(mapStateToProps)(ListItems);
+export default connect(mapStateToProps)(SimpleList);


### PR DESCRIPTION
I excluded the extra container components `AddItems` and `ListItems`. The `connect` HOC now applies directly to the original presentational components `AddPackingItem` and `SimpleList`.
Thanks.