### PR TITLE
Highlight the composite transactionality of microstates.

### DIFF
--- a/React/microstates/src/list.js
+++ b/React/microstates/src/list.js
@@ -3,7 +3,9 @@ export default class List {
   newItemText = String;
 
   addItem() {
-    return this.allItems.push(this.state.newItemText).newItemText.set("");
+    return this
+      .allItems.push(this.state.newItemText)
+      .newItemText.set("");
   }
 
   setNewItemText(text) {


### PR DESCRIPTION
One of the differentiators of working with microstates that sets it apart from other state management solutions is the focus on _composition_. In this case, the packing list state is composed from an array of Strings (`allItems`), and a single string (`newItemText`). Consequently the list transitions (`addItem`, `clear`) are composed out of the primitive string and array transitions.

It seems a small thing, but putting it all on one line hides the composite nature of the transitions, and also the "chaining transactionality". In other words, that changing a nested property actually changes the entire datastructure.

Our convention to highlight this has been that whenever you're making a transition that has multiple "transactions", to chain those together each on a new line.