### PR TITLE
Remove unnecessary concat from react-easy-state

### DIFF
--- a/ReactNative/ReactEasyState/store.js
+++ b/ReactNative/ReactEasyState/store.js
@@ -7,7 +7,7 @@ export const items = store({
     items.newItem = newItem
   },
   addItem () {
-    items.allItems = items.allItems.concat([items.newItem])
+    items.allItems.push(items.newItem)
     items.setNewItemValue()
   },
   clearItems () {


### PR DESCRIPTION
As requested [here](https://github.com/GantMan/ReactStateMuseum/pull/45#pullrequestreview-121111887) 🙂 