### PR TITLE
Fixing the typo (mapDispathToProps → mapDispatchToProps)

### DIFF
--- a/React/redux/src/Components/addItem.js
+++ b/React/redux/src/Components/addItem.js
@@ -6,10 +6,10 @@ const mapStateToProps = state => ({ value: state.items.newItemName });
 
 const { setNewItemName, addItem, clear } = ItemActionCreators;
 
-const mapDispathToProps = {
+const mapDispatchToProps = {
   setNewItemText: e => setNewItemName(e.target.value),
   addItem,
   clear
 };
 
-export default connect(mapStateToProps, mapDispathToProps)(AddPackingItem);
+export default connect(mapStateToProps, mapDispatchToProps)(AddPackingItem);


### PR DESCRIPTION
Hey,

I fixed the typo, as requested in #95 ;)