### PR TITLE
upgrade Expo to 32.0.0: pure-store

### DIFF
--- a/ReactNative/pure-store/.babelrc
+++ b/ReactNative/pure-store/.babelrc
@@ -1,8 +1,3 @@
 {
   "presets": ["babel-preset-expo"],
-  "env": {
-    "development": {
-      "plugins": ["transform-react-jsx-source"]
-    }
-  }
 }

--- a/ReactNative/pure-store/app.json
+++ b/ReactNative/pure-store/app.json
@@ -1,5 +1,5 @@
 {
   "expo": {
-    "sdkVersion": "27.0.0"
+    "sdkVersion": "32.0.0"
   }
 }

--- a/ReactNative/pure-store/package.json
+++ b/ReactNative/pure-store/package.json
@@ -3,26 +3,26 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "jest-expo": "~27.0.0",
+    "jest-expo": "^32.0.0",
     "react-native-scripts": "1.14.0",
-    "react-test-renderer": "16.3.1"
+    "react-test-renderer": "16.6.3"
   },
-  "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
+  "main": "node_modules/expo/AppEntry.js",
   "scripts": {
-    "start": "react-native-scripts start",
-    "eject": "react-native-scripts eject",
-    "android": "react-native-scripts android",
-    "ios": "react-native-scripts ios",
+    "start": "expo start",
+    "eject": "expo eject",
+    "android": "expo --android",
+    "ios": "expo --ios",
     "test": "jest"
   },
   "jest": {
     "preset": "jest-expo"
   },
   "dependencies": {
-    "expo": "^27.0.1",
+    "expo": "^32.0.0",
     "packlist-components": "^1.2.0",
     "pure-store": "^0.3.2",
-    "react": "16.3.1",
-    "react-native": "~0.55.2"
+    "react": "16.5.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz"
   }
 }


### PR DESCRIPTION
Updating the pure-store repo to Expo 32.0.0 (RN 0.0.57).

Check [here](https://github.com/GantMan/ReactStateMuseum/issues/115) for the list of updated repos.

Tested and working on both iOS Simulator (iOS 12) and Android Pixel (Pie).