### PR TITLE
Change test:all to clean up each example after running it

### DIFF
--- a/test/modules_test/index.js
+++ b/test/modules_test/index.js
@@ -4,7 +4,7 @@
 const bluebird = require( 'bluebird' );
 
 const {
-    
+
     getDirectories,
 
     constants: {
@@ -12,7 +12,7 @@ const {
         TEMPORARY_TEST_FILES
     }
 
-} = require( '../utils' ); 
+} = require( '../utils' );
 
 const testReactDirectory = require( './test_react_directory' );
 
@@ -24,11 +24,6 @@ const execa = require( 'execa' );
 describe( 'Modules Test', function() {
 
     this.timeout( Infinity );
-
-    before( function() {
-
-        return removeTemporaryTestFiles();
-    });
 
     [
         {
@@ -60,9 +55,9 @@ describe( 'Modules Test', function() {
         it( title, function() {
 
             return getDirectories({
-                
+
                 path: pathForLibraries
-            
+
             }).then( directories => {
 
                 // NOTE: used to run test on single directory
@@ -78,25 +73,25 @@ describe( 'Modules Test', function() {
             }).then( testResults => {
 
                 console.log(
-                    
+
                     'Results:',
-                    
+
                     JSON.stringify( testResults, null, 4 )
                 );
 
                 const errorDirectories = testResults.filter(
-                    
+
                     result => !!result.error
 
                 ).map(
-                    
+
                     errorResult => errorResult.directory
                 );
 
                 if( errorDirectories.length > 0 ) {
 
                     throw new Error(
-                        
+
                         `${ pathForLibraries } libraries that ` +
                         `failed the test: ` +
                         JSON.stringify( errorDirectories )
@@ -106,31 +101,3 @@ describe( 'Modules Test', function() {
         });
     });
 });
-
-
-// helper functions
-function removeTemporaryTestFiles() {
-
-    console.log( 'removing existing temporary test files' );
-
-    return execa(
-    
-        'rm', 
-
-        [
-            '-rf',
-            TEMPORARY_TEST_FILES,
-        ],
-
-        {
-            cwd: `${ process.cwd() }/test`
-        }
-    
-    ).then( () => {
-
-        console.log(
-            
-            'successfully removed existing temporary test files'
-        );
-    });
-}

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,13 +4,15 @@ const ROOT_PATH = '../';
 
 const { lstat, readdir } = require( 'fs' );
 
+const execa = require( 'execa' );
+
 
 const getDirectories = ({ path }) => {
 
     const fullPath = `${ __dirname }/${ ROOT_PATH }/${ path }`;
 
     return new Promise( ( resolve, reject ) => {
-        
+
         readdir( fullPath, ( err, contents ) => {
 
             if( !!err ) {
@@ -28,14 +30,14 @@ const getDirectories = ({ path }) => {
         contents.forEach( item => {
 
             const itemPath = (
-                
+
                 `${ __dirname }/${ ROOT_PATH }/${ path }/${ item }`
             );
-            
+
             const returnIfIsDirectoryPromise = new Promise(
-                
+
                 ( resolve, reject ) => {
-                    
+
                     lstat( itemPath, ( err, stats ) => {
 
                         if( !!err ) {
@@ -56,22 +58,42 @@ const getDirectories = ({ path }) => {
         });
 
         return Promise.all( returnIfIsDirectoryPromises );
-    
+
     }).then( returnIfIsDirectoryResults => {
 
         const directories = returnIfIsDirectoryResults.filter(
-            
+
             directoryOrNull => !!directoryOrNull
         );
-        
+
         return directories;
     });
+};
+
+const makeDirectoryCleanupFunction = (testDirectoryPath) => {
+    return (result) => {
+        console.log(`removing temporary directory ${testDirectoryPath}`);
+
+        return execa(
+            'rm',
+            [
+                '-rf',
+                testDirectoryPath
+            ]
+        ).then(() => {
+            console.log('successfully removed temporary directory');
+
+            return result;
+        });
+    };
 };
 
 
 module.exports = {
 
     getDirectories,
+
+    makeDirectoryCleanupFunction,
 
     constants: {
 


### PR DESCRIPTION
Issue: #91 

I ran out of space on disk when first running the exhaustive tests. :sweat_smile: I think it uses > 10GB of space for all the dependencies of all the examples. 

This PR improves the exhaustive tests to clean up each example after running it. My editor also cleaned up some whitespace (I recommend hiding whitespaces changes on the diff).

Regarding the old `removeTemporaryTestFiles` approach of removing the entire temp folder at the beginning of the exhaustive test suite, I was worried about removing it since it might cause issues for users who have run the exhaustive test suite already and will have the example folders already there. But on second thought and after some sanity checks, it shouldn't be an issue since the worst thing that could happen is that `yarn install` is run and the dependencies are already there.

Also, while working on this, I noticed some examples are not passing. I will try to fix them in a separate PR.